### PR TITLE
Support promise cancellation

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -30,10 +30,15 @@ function timeout(PromiseInterface $promise, $time, LoopInterface $loop)
 
 function resolve($time, LoopInterface $loop)
 {
-    return new Promise(function ($resolve) use ($loop, $time) {
-        $loop->addTimer($time, function () use ($time, $resolve) {
+    return new Promise(function ($resolve) use ($loop, $time, &$timer) {
+        // resolve the promise when the timer fires in $time seconds
+        $timer = $loop->addTimer($time, function () use ($time, $resolve) {
             $resolve($time);
         });
+    }, function ($resolveUnused, $reject) use (&$timer, $loop) {
+        // cancelling this promise will cancel the timer and reject
+        $loop->cancelTimer($timer);
+        $reject(new \RuntimeException('Timer cancelled'));
     });
 }
 

--- a/tests/FunctionRejectTest.php
+++ b/tests/FunctionRejectTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Clue\Promise\Timer;
+use React\Promise\CancellablePromiseInterface;
 
 class FunctionRejectTest extends TestCase
 {
@@ -16,6 +17,19 @@ class FunctionRejectTest extends TestCase
         $promise = Timer\reject(0.01, $this->loop);
 
         $this->loop->run();
+
+        $this->expectPromiseRejected($promise);
+    }
+
+    public function testCancelingPromiseWillRejectTimer()
+    {
+        $promise = Timer\reject(0.01, $this->loop);
+
+        if (!($promise instanceof CancellablePromiseInterface)) {
+            $this->markTestSkipped('Outdated Promise API');
+        }
+
+        $promise->cancel();
 
         $this->expectPromiseRejected($promise);
     }

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Clue\Promise\Timer;
+use React\Promise\CancellablePromiseInterface;
 
 class FunctionResolveTest extends TestCase
 {
@@ -18,5 +19,44 @@ class FunctionResolveTest extends TestCase
         $this->loop->run();
 
         $this->expectPromiseResolved($promise);
+    }
+
+    public function testWillStartLoopTimer()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+        $loop->expects($this->once())->method('addTimer')->with($this->equalTo(0.01));
+
+        Timer\resolve(0.01, $loop);
+    }
+
+    public function testCancellingPromiseWillCancelLoopTimer()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
+        $loop->expects($this->once())->method('addTimer')->will($this->returnValue($timer));
+
+        $promise = Timer\resolve(0.01, $loop);
+
+        if (!($promise instanceof CancellablePromiseInterface)) {
+            $this->markTestSkipped('Outdated Promise API');
+        }
+
+        $loop->expects($this->once())->method('cancelTimer')->with($this->equalTo($timer));
+
+        $promise->cancel();
+    }
+
+    public function testCancelingPromiseWillRejectTimer()
+    {
+        $promise = Timer\resolve(0.01, $this->loop);
+
+        if (!($promise instanceof CancellablePromiseInterface)) {
+            $this->markTestSkipped('Outdated Promise API');
+        }
+
+        $promise->cancel();
+
+        $this->expectPromiseRejected($promise);
     }
 }

--- a/tests/FunctionTimeoutTest.php
+++ b/tests/FunctionTimeoutTest.php
@@ -75,6 +75,40 @@ class FunctionTimerTest extends TestCase
         $this->loop->run();
     }
 
+    public function testCancelTimeoutWillCancelTimerAndReject()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
+            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
+        }
+
+        $promise = new \React\Promise\Promise(function () { });
+
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
+        $loop->expects($this->once())->method('addTimer')->will($this->returnValue($timer));
+        $loop->expects($this->once())->method('cancelTimer')->with($this->equalTo($timer));
+
+        $timeout = Timer\timeout($promise, 0.01, $loop);
+
+        $timeout->cancel();
+
+        $this->expectPromiseRejected($timeout);
+    }
+
+    public function testCancelTimeoutWillCancelGivenPromise()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
+            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
+        }
+
+        $promise = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
+
+        $timeout = Timer\timeout($promise, 0.01, $this->loop);
+
+        $timeout->cancel();
+    }
+
     public function testCancelGivenPromiseWillReject()
     {
         if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {

--- a/tests/FunctionTimeoutTest.php
+++ b/tests/FunctionTimeoutTest.php
@@ -74,4 +74,20 @@ class FunctionTimerTest extends TestCase
 
         $this->loop->run();
     }
+
+    public function testCancelGivenPromiseWillReject()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
+            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
+        }
+
+        $promise = new \React\Promise\Promise(function () { }, function ($resolve, $reject) { $reject(); });
+
+        $timeout = Timer\timeout($promise, 0.01, $this->loop);
+
+        $promise->cancel();
+
+        $this->expectPromiseRejected($promise);
+        $this->expectPromiseRejected($timeout);
+    }
 }


### PR DESCRIPTION
* Add cancellation support for `resolve()` and `reject()`
  * Remove internal timers
  * Reject resulting promise with `RuntimeException`
* Add cancellation support for `timeout()`
  * Remove internal timers
  * Reject resulting promise with `RuntimeException`
  * Also cancel input promise (see #3 for some background)
* Cancellation of input promise for `timeout()` is not affected

Closes #3