### PR TITLE
Support promise cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,37 @@ is likely one of your smaller problems.
 For more details on the promise cancellation, please refer to the
 [Promise documentation](https://github.com/reactphp/promise#cancellablepromiseinterface).
 
+#### Input cancellation
+
+Irrespective of the timout handling, you can also explicitly `cancel()` the
+input `$promise` at any time.
+This means that the `timeout()` handling does not affect cancellation of the
+input `$promise`, as demonstrated in the following example:
+
+```php
+$promise = accessSomeRemoteResource();
+$timeout = Timer\timeout($promise, 10.0, $loop);
+
+$promise->cancel();
+```
+
+The registered [cancellation handler](#cancellation-handler) is responsible for
+handling the `cancel()` call:
+
+* A described above, a common use involves resource cleanup and will then *reject*
+  the `Promise`.
+  If the input `$promise` is being rejected, then the timeout will be aborted
+  and the resulting promise will also be rejected.
+* If the input `$promise` is still pending, then the timout will continue
+  running until the timer expires.
+  The same happens if the input `$promise` does not register a
+  [cancellation handler](#cancellation-handler). 
+
+> Note: If you're stuck on legacy versions (PHP 5.3), then the `cancel()` method
+is not available, as the Promise cancellation API is currently only available in
+[react/promise v2.1.0](https://github.com/reactphp/promise)
+which in turn requires PHP 5.4 or up.
+
 #### Collections
 
 If you want to wait for multiple promises to resolve, you can use the normal promise primitives like this:

--- a/README.md
+++ b/README.md
@@ -132,13 +132,6 @@ If no cancellation handler is passed to the `Promise` constructor, then invoking
 its `cancel()` method it is effectively a NO-OP.
 This means that it may still be pending and can hence continue consuming resources.
 
-> Note: If you're stuck on legacy versions (PHP 5.3), then this is also a NO-OP,
-as the Promise cancellation API is currently only available in
-[react/promise v2.1.0](https://github.com/reactphp/promise)
-which in turn requires PHP 5.4 or up.
-It is assumed that if you're actually still stuck on PHP 5.3, resource cleanup
-is likely one of your smaller problems. 
-
 For more details on the promise cancellation, please refer to the
 [Promise documentation](https://github.com/reactphp/promise#cancellablepromiseinterface).
 
@@ -167,11 +160,6 @@ handling the `cancel()` call:
   running until the timer expires.
   The same happens if the input `$promise` does not register a
   [cancellation handler](#cancellation-handler). 
-
-> Note: If you're stuck on legacy versions (PHP 5.3), then the `cancel()` method
-is not available, as the Promise cancellation API is currently only available in
-[react/promise v2.1.0](https://github.com/reactphp/promise)
-which in turn requires PHP 5.4 or up.
 
 #### Output cancellation
 
@@ -229,11 +217,6 @@ This means that while the resulting promise will still be rejected after the
 timeout, the underlying input `$promise` may still be pending and can hence
 continue consuming resources.
 
-> Note: If you're stuck on legacy versions (PHP 5.3), then the `cancel()` method
-is not available, as the Promise cancellation API is currently only available in
-[react/promise v2.1.0](https://github.com/reactphp/promise)
-which in turn requires PHP 5.4 or up.
-
 #### Collections
 
 If you want to wait for multiple promises to resolve, you can use the normal promise primitives like this:
@@ -280,11 +263,6 @@ $timer->cancel();
 
 This will abort the timer and *reject* with a `RuntimeException`.
 
-> Note: If you're stuck on legacy versions (PHP 5.3), then the `cancel()` method
-is not available, as the Promise cancellation API is currently only available in
-[react/promise v2.1.0](https://github.com/reactphp/promise)
-which in turn requires PHP 5.4 or up.
-
 ### reject()
 
 The `reject($time, LoopInterface $loop)` function can be used to create a new Promise
@@ -311,11 +289,6 @@ $timer->cancel();
 
 This will abort the timer and *reject* with a `RuntimeException`.
 
-> Note: If you're stuck on legacy versions (PHP 5.3), then the `cancel()` method
-is not available, as the Promise cancellation API is currently only available in
-[react/promise v2.1.0](https://github.com/reactphp/promise)
-which in turn requires PHP 5.4 or up.
-
 ### TimeoutException
 
 The `TimeoutException` extends PHP's built-in `RuntimeException`.
@@ -334,12 +307,6 @@ The recommended way to install this library is [through composer](http://getcomp
     }
 }
 ```
-
-> Note: If you're stuck on legacy versions (PHP 5.3), then the `cancel()` method
-is not available,
-as the Promise cancellation API is currently only available in
-[react/promise v2.1.0](https://github.com/reactphp/promise)
-which in turn requires PHP 5.4 or up.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,23 @@ Timer\resolve(1.5, $loop)->then(function ($time) {
 });
 ```
 
+#### Resolve cancellation
+
+You can explicitly `cancel()` the resulting timer promise at any time:
+
+```php
+$timer = Timer\resolve(2.0, $loop);
+
+$timer->cancel();
+```
+
+This will abort the timer and *reject* with a `RuntimeException`.
+
+> Note: If you're stuck on legacy versions (PHP 5.3), then the `cancel()` method
+is not available, as the Promise cancellation API is currently only available in
+[react/promise v2.1.0](https://github.com/reactphp/promise)
+which in turn requires PHP 5.4 or up.
+
 ### reject()
 
 The `reject($time, LoopInterface $loop)` function can be used to create a new Promise
@@ -183,12 +200,29 @@ which rejects in `$time` seconds with a `TimeoutException`.
 
 ```php
 Timer\reject(2.0, $loop)->then(null, function (TimeoutException $e) {
-    echo '
+    echo 'Rejected after ' . $e->getTimeout() . ' seconds ' . PHP_EOL;
 });
 ```
 
 This function complements the [`resolve()`](#resolve) function
 and can be used as a basic building block for higher-level promise consumers.
+
+#### Reject cancellation
+
+You can explicitly `cancel()` the resulting timer promise at any time:
+
+```php
+$timer = Timer\reject(2.0, $loop);
+
+$timer->cancel();
+```
+
+This will abort the timer and *reject* with a `RuntimeException`.
+
+> Note: If you're stuck on legacy versions (PHP 5.3), then the `cancel()` method
+is not available, as the Promise cancellation API is currently only available in
+[react/promise v2.1.0](https://github.com/reactphp/promise)
+which in turn requires PHP 5.4 or up.
 
 ### TimeoutException
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "require": {
         "php": ">=5.3",
         "react/event-loop": "~0.4.0|~0.3.0",
-        "react/promise": "~2.0|~1.1"
+        "react/promise": "~2.1|~1.2"
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -9,6 +9,13 @@ use React\Promise\Promise;
 
 function timeout(PromiseInterface $promise, $time, LoopInterface $loop)
 {
+    // cancelling this promise will only try to cancel the input promise,
+    // thus leaving responsibility to the input promise.
+    $canceller = null;
+    if ($promise instanceof CancellablePromiseInterface) {
+        $canceller = array($promise, 'cancel');
+    }
+
     return new Promise(function ($resolve, $reject) use ($loop, $time, $promise) {
         $timer = $loop->addTimer($time, function () use ($time, $promise, $reject) {
             $reject(new TimeoutException($time, 'Timed out after ' . $time . ' seconds'));
@@ -25,7 +32,7 @@ function timeout(PromiseInterface $promise, $time, LoopInterface $loop)
             $loop->cancelTimer($timer);
             $reject($v);
         });
-    });
+    }, $canceller);
 }
 
 function resolve($time, LoopInterface $loop)

--- a/src/functions.php
+++ b/src/functions.php
@@ -30,10 +30,15 @@ function timeout(PromiseInterface $promise, $time, LoopInterface $loop)
 
 function resolve($time, LoopInterface $loop)
 {
-    return new Promise(function ($resolve) use ($loop, $time) {
-        $loop->addTimer($time, function () use ($time, $resolve) {
+    return new Promise(function ($resolve) use ($loop, $time, &$timer) {
+        // resolve the promise when the timer fires in $time seconds
+        $timer = $loop->addTimer($time, function () use ($time, $resolve) {
             $resolve($time);
         });
+    }, function ($resolveUnused, $reject) use (&$timer, $loop) {
+        // cancelling this promise will cancel the timer and reject
+        $loop->cancelTimer($timer);
+        $reject(new \RuntimeException('Timer cancelled'));
     });
 }
 

--- a/tests/FunctionRejectTest.php
+++ b/tests/FunctionRejectTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use React\Promise\Timer;
+use React\Promise\CancellablePromiseInterface;
 
 class FunctionRejectTest extends TestCase
 {
@@ -16,6 +17,19 @@ class FunctionRejectTest extends TestCase
         $promise = Timer\reject(0.01, $this->loop);
 
         $this->loop->run();
+
+        $this->expectPromiseRejected($promise);
+    }
+
+    public function testCancelingPromiseWillRejectTimer()
+    {
+        $promise = Timer\reject(0.01, $this->loop);
+
+        if (!($promise instanceof CancellablePromiseInterface)) {
+            $this->markTestSkipped('Outdated Promise API');
+        }
+
+        $promise->cancel();
 
         $this->expectPromiseRejected($promise);
     }

--- a/tests/FunctionRejectTest.php
+++ b/tests/FunctionRejectTest.php
@@ -25,10 +25,6 @@ class FunctionRejectTest extends TestCase
     {
         $promise = Timer\reject(0.01, $this->loop);
 
-        if (!($promise instanceof CancellablePromiseInterface)) {
-            $this->markTestSkipped('Outdated Promise API');
-        }
-
         $promise->cancel();
 
         $this->expectPromiseRejected($promise);

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -38,10 +38,6 @@ class FunctionResolveTest extends TestCase
 
         $promise = Timer\resolve(0.01, $loop);
 
-        if (!($promise instanceof CancellablePromiseInterface)) {
-            $this->markTestSkipped('Outdated Promise API');
-        }
-
         $loop->expects($this->once())->method('cancelTimer')->with($this->equalTo($timer));
 
         $promise->cancel();
@@ -50,10 +46,6 @@ class FunctionResolveTest extends TestCase
     public function testCancelingPromiseWillRejectTimer()
     {
         $promise = Timer\resolve(0.01, $this->loop);
-
-        if (!($promise instanceof CancellablePromiseInterface)) {
-            $this->markTestSkipped('Outdated Promise API');
-        }
 
         $promise->cancel();
 

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use React\Promise\Timer;
+use React\Promise\CancellablePromiseInterface;
 
 class FunctionResolveTest extends TestCase
 {
@@ -18,5 +19,44 @@ class FunctionResolveTest extends TestCase
         $this->loop->run();
 
         $this->expectPromiseResolved($promise);
+    }
+
+    public function testWillStartLoopTimer()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+        $loop->expects($this->once())->method('addTimer')->with($this->equalTo(0.01));
+
+        Timer\resolve(0.01, $loop);
+    }
+
+    public function testCancellingPromiseWillCancelLoopTimer()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
+        $loop->expects($this->once())->method('addTimer')->will($this->returnValue($timer));
+
+        $promise = Timer\resolve(0.01, $loop);
+
+        if (!($promise instanceof CancellablePromiseInterface)) {
+            $this->markTestSkipped('Outdated Promise API');
+        }
+
+        $loop->expects($this->once())->method('cancelTimer')->with($this->equalTo($timer));
+
+        $promise->cancel();
+    }
+
+    public function testCancelingPromiseWillRejectTimer()
+    {
+        $promise = Timer\resolve(0.01, $this->loop);
+
+        if (!($promise instanceof CancellablePromiseInterface)) {
+            $this->markTestSkipped('Outdated Promise API');
+        }
+
+        $promise->cancel();
+
+        $this->expectPromiseRejected($promise);
     }
 }

--- a/tests/FunctionTimeoutTest.php
+++ b/tests/FunctionTimeoutTest.php
@@ -62,10 +62,6 @@ class FunctionTimerTest extends TestCase
 
     public function testPendingCancellableWillBeCancelledOnTimeout()
     {
-        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
-            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
-        }
-
         $promise = $this->getMock('React\Promise\CancellablePromiseInterface');
         $promise->expects($this->once())->method('cancel');
 
@@ -76,10 +72,6 @@ class FunctionTimerTest extends TestCase
 
     public function testCancelTimeoutWithoutCancellationhandlerWillNotCancelTimerAndWillNotReject()
     {
-        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
-            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
-        }
-
         $promise = new \React\Promise\Promise(function () { });
 
         $loop = $this->getMock('React\EventLoop\LoopInterface');
@@ -97,10 +89,6 @@ class FunctionTimerTest extends TestCase
 
     public function testCancelTimeoutWillCancelGivenPromise()
     {
-        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
-            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
-        }
-
         $promise = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
 
         $timeout = Timer\timeout($promise, 0.01, $this->loop);
@@ -110,10 +98,6 @@ class FunctionTimerTest extends TestCase
 
     public function testCancelGivenPromiseWillReject()
     {
-        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
-            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
-        }
-
         $promise = new \React\Promise\Promise(function () { }, function ($resolve, $reject) { $reject(); });
 
         $timeout = Timer\timeout($promise, 0.01, $this->loop);
@@ -126,10 +110,6 @@ class FunctionTimerTest extends TestCase
 
     public function testCancelTimeoutWillRejectIfGivenPromiseWillReject()
     {
-        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
-            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
-        }
-
         $promise = new \React\Promise\Promise(function () { }, function ($resolve, $reject) { $reject(); });
 
         $timeout = Timer\timeout($promise, 0.01, $this->loop);
@@ -142,10 +122,6 @@ class FunctionTimerTest extends TestCase
 
     public function testCancelTimeoutWillResolveIfGivenPromiseWillResolve()
     {
-        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
-            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
-        }
-
         $promise = new \React\Promise\Promise(function () { }, function ($resolve, $reject) { $resolve(); });
 
         $timeout = Timer\timeout($promise, 0.01, $this->loop);

--- a/tests/FunctionTimeoutTest.php
+++ b/tests/FunctionTimeoutTest.php
@@ -74,4 +74,20 @@ class FunctionTimerTest extends TestCase
 
         $this->loop->run();
     }
+
+    public function testCancelGivenPromiseWillReject()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface', true)) {
+            $this->markTestSkipped('Your (outdated?) Promise API does not support cancellable promises');
+        }
+
+        $promise = new \React\Promise\Promise(function () { }, function ($resolve, $reject) { $reject(); });
+
+        $timeout = Timer\timeout($promise, 0.01, $this->loop);
+
+        $promise->cancel();
+
+        $this->expectPromiseRejected($promise);
+        $this->expectPromiseRejected($timeout);
+    }
 }


### PR DESCRIPTION
* Add cancellation support for `resolve()` and `reject()`
  * Remove internal timers
  * Reject resulting promise with `RuntimeException`
* Add cancellation support for `timeout()`
  * Only cancel input promise (see #13 for some background, thanks @jsor)
* Cancellation of input promise for `timeout()` is not affected

Closes #3, supersedes/closes #13