### PR TITLE
Cap minimum timer interval at 1µs across all versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/event-loop": "~0.4.0|~0.3.0",
+        "react/event-loop": "^0.4 || ^0.3.5",
         "react/promise": "~2.1|~1.2"
     }
 }

--- a/tests/FunctionRejectTest.php
+++ b/tests/FunctionRejectTest.php
@@ -13,9 +13,25 @@ class FunctionRejectTest extends TestCase
         $this->expectPromisePending($promise);
     }
 
+    public function testPromiseExpiredIsPendingWithoutRunningLoop()
+    {
+        $promise = Timer\reject(-1, $this->loop);
+
+        $this->expectPromisePending($promise);
+    }
+
     public function testPromiseWillBeRejectedOnTimeout()
     {
         $promise = Timer\reject(0.01, $this->loop);
+
+        $this->loop->run();
+
+        $this->expectPromiseRejected($promise);
+    }
+
+    public function testPromiseExpiredWillBeRejectedOnTimeout()
+    {
+        $promise = Timer\reject(-1, $this->loop);
 
         $this->loop->run();
 

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -13,9 +13,25 @@ class FunctionResolveTest extends TestCase
         $this->expectPromisePending($promise);
     }
 
+    public function testPromiseExpiredIsPendingWithoutRunningLoop()
+    {
+        $promise = Timer\resolve(-1, $this->loop);
+
+        $this->expectPromisePending($promise);
+    }
+
     public function testPromiseWillBeResolvedOnTimeout()
     {
         $promise = Timer\resolve(0.01, $this->loop);
+
+        $this->loop->run();
+
+        $this->expectPromiseResolved($promise);
+    }
+
+    public function testPromiseExpiredWillBeResolvedOnTimeout()
+    {
+        $promise = Timer\resolve(-1, $this->loop);
 
         $this->loop->run();
 

--- a/tests/FunctionTimeoutTest.php
+++ b/tests/FunctionTimeoutTest.php
@@ -16,6 +16,15 @@ class FunctionTimerTest extends TestCase
         $this->expectPromiseResolved($promise);
     }
 
+    public function testResolvedExpiredWillResolveRightAway()
+    {
+        $promise = Promise\resolve();
+
+        $promise = Timer\timeout($promise, -1, $this->loop);
+
+        $this->expectPromiseResolved($promise);
+    }
+
     public function testResolvedWillNotStartTimer()
     {
         $promise = Promise\resolve();


### PR DESCRIPTION
Closes #6 and builds on top of https://github.com/reactphp/event-loop/pull/47