### PR TITLE
Improve memory consumption by cleaning up unneeded references

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -55,10 +55,12 @@ function resolve($time, LoopInterface $loop)
         $timer = $loop->addTimer($time, function () use ($time, $resolve) {
             $resolve($time);
         });
-    }, function ($resolveUnused, $reject) use (&$timer, $loop) {
+    }, function ($resolve, $reject, $notify) use (&$timer, $loop) {
         // cancelling this promise will cancel the timer and reject
         $loop->cancelTimer($timer);
-        $reject(new \RuntimeException('Timer cancelled'));
+
+        $resolve = $reject = $notify = $timer = $loop = null;
+        throw new \RuntimeException('Timer cancelled');
     });
 }
 


### PR DESCRIPTION
While debugging some very odd memory issues in a live application, I noticed that this component shows some unexpected memory consumption and memory would not immediately be freed as expected. Let's not call this a "memory leak", because memory was eventually freed, but this clearly caused some unexpected and significant memory growth.

One of the core issues has been located and addressed via https://github.com/reactphp/event-loop/pull/164, but even with that patch applied the `resolve()` method behaved a bit unexpected.

I've used the following script to demonstrate unreasonable memory growth:

```php
<?php

use React\EventLoop\Factory;

require __DIR__ . '/../vendor/autoload.php';

$loop = Factory::create();

$loop->addPeriodicTimer(0.001, function () use ($loop) {
    $promise = \React\Promise\Timer\resolve(60.0, $loop);
    $promise->cancel();
});

$loop->addPeriodicTimer(1.0, function () {
    echo memory_get_usage() . PHP_EOL;
});

$loop->run();
```

Initially this peaked at around 320 MB on my system. After applying the referenced patch, this went down significantly and fluctuated somewhere between 1 MB and 12 MB. After applying this patch, this script reports a constant memory consumption of around 0.7 MB.

This implementation includes some of the ideas discussed in https://github.com/reactphp/promise/issues/46 and https://github.com/reactphp/socket/pull/113. Eventually, we should look into providing a way to address this within our promise implementation.

My vote would to be get this in here now as it addresses a relevant memory issue and eventually address this in the upstream component (at which point this changeset also does no harm). :shipit: 