### PR TITLE
Improve memory consumption by cleaning up garbage references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.3",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
-        "react/promise": "~2.1|~1.2"
+        "react/promise": "^2.6.0 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"

--- a/tests/FunctionRejectTest.php
+++ b/tests/FunctionRejectTest.php
@@ -38,12 +38,42 @@ class FunctionRejectTest extends TestCase
         $this->expectPromiseRejected($promise);
     }
 
-    public function testCancelingPromiseWillRejectTimer()
+    public function testCancellingPromiseWillRejectTimer()
     {
         $promise = Timer\reject(0.01, $this->loop);
 
         $promise->cancel();
 
         $this->expectPromiseRejected($promise);
+    }
+
+    public function testWaitingForPromiseToRejectDoesNotLeaveGarbageCycles()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Timer\reject(0.01, $this->loop);
+        $this->loop->run();
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testCancellingPromiseDoesNotLeaveGarbageCycles()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Timer\reject(0.01, $this->loop);
+        $promise->cancel();
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
     }
 }

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -60,12 +60,42 @@ class FunctionResolveTest extends TestCase
         $promise->cancel();
     }
 
-    public function testCancelingPromiseWillRejectTimer()
+    public function testCancellingPromiseWillRejectTimer()
     {
         $promise = Timer\resolve(0.01, $this->loop);
 
         $promise->cancel();
 
         $this->expectPromiseRejected($promise);
+    }
+
+    public function testWaitingForPromiseToResolveDoesNotLeaveGarbageCycles()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Timer\resolve(0.01, $this->loop);
+        $this->loop->run();
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testCancellingPromiseDoesNotLeaveGarbageCycles()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Timer\resolve(0.01, $this->loop);
+        $promise->cancel();
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
     }
 }


### PR DESCRIPTION
While debugging some very odd memory issues in a live application, I noticed that this component shows some unexpected memory consumption and memory would not immediately be freed as expected. Let's not call this a "memory leak", because memory was eventually freed, but this clearly caused some unexpected and significant memory growth.

Parts of this issue have been resolved with #32 already which raised the discussion to address these issues in the upstream react/promise component. A number of patches have been filed via https://github.com/reactphp/promise/pull/113, https://github.com/reactphp/promise/pull/115, https://github.com/reactphp/promise/pull/116 and https://github.com/reactphp/promise/pull/117.

I'm marking this PR as WIP because the referenced changes are yet to be released as part of react/promise v2.6.0. Once this release is out, I'll update the version reference and this should be ready to be shipped.

This PR actually includes a number of tests that show how garbage memory references are no longer an issue in any supported PHP version and how these functions no longer cause any such references on their own (unlike the previous changes in #32 this means that we can now test this and this requires no effort on the consumer side anymore).