### PR TITLE
Improve memory consumption by cleaning up garbage references to pending promise without canceller

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.3",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
-        "react/promise": "^2.6.0 || ^1.2.1"
+        "react/promise": "^2.7.0 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,7 +23,7 @@ function timeout(PromiseInterface $promise, $time, LoopInterface $loop)
 
     return new Promise(function ($resolve, $reject) use ($loop, $time, $promise) {
         $timer = null;
-        $promise->then(function ($v) use (&$timer, $loop, $resolve) {
+        $promise = $promise->then(function ($v) use (&$timer, $loop, $resolve) {
             if ($timer) {
                 $loop->cancelTimer($timer);
             }


### PR DESCRIPTION
The previous changes in #33 improved memory consumption for settled promises somewhat. Similarly, this PR addresses memory consumption for pending promises that are no longer referenced.

Calling `timeout()` on a promise which has no canceller function does successfully reject the promise. However, due to internal references, it keeps a cyclic reference to the input promise and as such shows some unexpected memory consumption and memory would not immediately be freed as expected. Let's not call this a "memory leak", because memory was eventually freed, but this clearly caused some unexpected and significant memory growth.

I'm marking this PR as WIP because this includes a test for reactphp/promise#124 which is yet to be released as part of react/promise v2.7.0. Once this release is out, I'll update the version reference and this should be ready to be shipped.

Builds on top of #33 