### PR TITLE
Check if the function is declared before declaring it.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "autoload": {
         "psr-4": { "React\\Promise\\Timer\\": "src/" },
-        "files": [ "src/functions.php" ]
+        "files": [ "src/functions_include.php" ]
     },
     "autoload-dev": {
         "psr-4": { "React\\Tests\\Promise\\Timer\\": "tests/" }

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace React\Promise\Timer;
+
+if (!function_exists('React\\Promise\\Timer\\timeout')) {
+    require __DIR__ . '/functions.php';
+}


### PR DESCRIPTION
In case you use pthreads or something else related to threading you might encounter this issue. It happens only with functions and is fixable only by adding these checks. Another way to avoid this is to wrap functions as static into classes.