### PR TITLE
TimeoutException: fix defaults to avoid notices with PHP 8.1

### DIFF
--- a/src/TimeoutException.php
+++ b/src/TimeoutException.php
@@ -10,6 +10,13 @@ class TimeoutException extends RuntimeException
 
     public function __construct($timeout, $message = null, $code = null, $previous = null)
     {
+        // Preserve compatibility with our former signature, but avoid invalid arguments for the parent constructor:
+        if ($message === null) {
+            $message = '';
+        }
+        if ($code === null) {
+            $code = 0;
+        }
         parent::__construct($message, $code, $previous);
 
         $this->timeout = $timeout;

--- a/tests/TimeoutExceptionTest.php
+++ b/tests/TimeoutExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Promise\Timer;
 
+use ErrorException;
 use React\Promise\Timer\TimeoutException;
 
 class TimeoutExceptionTest extends TestCase
@@ -11,5 +12,37 @@ class TimeoutExceptionTest extends TestCase
         $e = new TimeoutException(10);
 
         $this->assertEquals(10, $e->getTimeout());
+    }
+
+    public function testEnsureNoDeprecationsAreTriggered()
+    {
+        $formerReporting = error_reporting();
+        error_reporting(E_ALL | E_STRICT);
+        $this->setStrictErrorHandling();
+
+        try {
+            $e = new TimeoutException(10);
+        } catch (ErrorException $e) {
+            error_reporting($formerReporting);
+            throw $e;
+        }
+
+        error_reporting($formerReporting);
+        $this->assertEquals(10, $e->getTimeout());
+    }
+
+    protected function setStrictErrorHandling()
+    {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            if (! (error_reporting() & $errno)) {
+                return false;
+            }
+            switch ($errno) {
+                case E_DEPRECATED:
+                    throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+            }
+
+            return false;
+        });
     }
 }


### PR DESCRIPTION
When being strict about deprecations, once reaching a `timeout()`, your code will fail on PHP 8.1. That's what this pull request attempts to fix.

Hint: created two distinct commits, the first one allows to trigger the error. You can have a look at a failing test run [here](https://github.com/Thomas-Gelf/promise-timer/runs/4355027401?check_suite_focus=true).