### PR TITLE
Add new `sleep()` function and deprecate `resolve()` and `reject()` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A trivial implementation of timeouts for `Promise`s, built on top of [ReactPHP](
 * [Usage](#usage)
     * [timeout()](#timeout)
     * [sleep()](#sleep)
-    * [resolve()](#resolve)
-    * [reject()](#reject)
+    * [~~resolve()~~](#resolve)
+    * [~~reject()~~](#reject)
     * [TimeoutException](#timeoutexception)
         * [getTimeout()](#gettimeout)
 * [Install](#install)
@@ -204,7 +204,9 @@ $timer = React\Promise\Timer\sleep(2.0);
 $timer->cancel();
 ```
 
-### resolve()
+### ~~resolve()~~
+
+> Deprecated since v1.8.0, see [`sleep()`](#sleep) instead.
 
 The `resolve(float $time, ?LoopInterface $loop = null): PromiseInterface<float, RuntimeException>` function can be used to
 create a new promise that resolves in `$time` seconds with the `$time` as the fulfillment value.
@@ -236,7 +238,9 @@ $timer = React\Promise\Timer\resolve(2.0);
 $timer->cancel();
 ```
 
-### reject()
+### ~~reject()~~
+
+> Deprecated since v1.8.0, see [`sleep()`](#sleep) instead.
 
 The `reject(float $time, ?LoopInterface $loop = null): PromiseInterface<void, TimeoutException|RuntimeException>` function can be used to
 create a new promise which rejects in `$time` seconds with a `TimeoutException`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A trivial implementation of timeouts for `Promise`s, built on top of [ReactPHP](
 
 * [Usage](#usage)
     * [timeout()](#timeout)
+    * [sleep()](#sleep)
     * [resolve()](#resolve)
     * [reject()](#reject)
     * [TimeoutException](#timeoutexception)
@@ -170,6 +171,38 @@ The applies to all promise collection primitives alike, i.e. `all()`,
 
 For more details on the promise primitives, please refer to the
 [Promise documentation](https://github.com/reactphp/promise#functions).
+
+### sleep()
+
+The `sleep(float $time, ?LoopInterface $loop = null): PromiseInterface<void, RuntimeException>` function can be used to
+create a new promise that resolves in `$time` seconds.
+
+```php
+React\Promise\Timer\sleep(1.5)->then(function () {
+    echo 'Thanks for waiting!' . PHP_EOL;
+});
+```
+
+Internally, the given `$time` value will be used to start a timer that will
+resolve the promise once it triggers. This implies that if you pass a really
+small (or negative) value, it will still start a timer and will thus trigger
+at the earliest possible time in the future.
+
+This function takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use. You can use a `null` value here in order to
+use the [default loop](https://github.com/reactphp/event-loop#loop). This value
+SHOULD NOT be given unless you're sure you want to explicitly use a given event
+loop instance.
+
+The returned promise is implemented in such a way that it can be cancelled
+when it is still pending. Cancelling a pending promise will reject its value
+with a `RuntimeException` and clean up any pending timers.
+
+```php
+$timer = React\Promise\Timer\sleep(2.0);
+
+$timer->cancel();
+```
 
 ### resolve()
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -249,7 +249,7 @@ function sleep($time, LoopInterface $loop = null)
 }
 
 /**
- * Create a new promise that resolves in `$time` seconds with the `$time` as the fulfillment value.
+ * [Deprecated] Create a new promise that resolves in `$time` seconds with the `$time` as the fulfillment value.
  *
  * ```php
  * React\Promise\Timer\resolve(1.5)->then(function ($time) {
@@ -281,6 +281,8 @@ function sleep($time, LoopInterface $loop = null)
  * @param float $time
  * @param ?LoopInterface $loop
  * @return PromiseInterface<float, \RuntimeException>
+ * @deprecated 1.8.0 See `sleep()` instead
+ * @see sleep()
  */
 function resolve($time, LoopInterface $loop = null)
 {
@@ -290,7 +292,7 @@ function resolve($time, LoopInterface $loop = null)
 }
 
 /**
- * Create a new promise which rejects in `$time` seconds with a `TimeoutException`.
+ * [Deprecated] Create a new promise which rejects in `$time` seconds with a `TimeoutException`.
  *
  * ```php
  * React\Promise\Timer\reject(2.0)->then(null, function (React\Promise\Timer\TimeoutException $e) {
@@ -322,6 +324,8 @@ function resolve($time, LoopInterface $loop = null)
  * @param float         $time
  * @param LoopInterface $loop
  * @return PromiseInterface<void, TimeoutException|\RuntimeException>
+ * @deprecated 1.8.0 See `sleep()` instead
+ * @see sleep()
  */
 function reject($time, LoopInterface $loop = null)
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -193,6 +193,62 @@ function timeout(PromiseInterface $promise, $time, LoopInterface $loop = null)
 }
 
 /**
+ * Create a new promise that resolves in `$time` seconds.
+ *
+ * ```php
+ * React\Promise\Timer\sleep(1.5)->then(function () {
+ *     echo 'Thanks for waiting!' . PHP_EOL;
+ * });
+ * ```
+ *
+ * Internally, the given `$time` value will be used to start a timer that will
+ * resolve the promise once it triggers. This implies that if you pass a really
+ * small (or negative) value, it will still start a timer and will thus trigger
+ * at the earliest possible time in the future.
+ *
+ * This function takes an optional `LoopInterface|null $loop` parameter that can be used to
+ * pass the event loop instance to use. You can use a `null` value here in order to
+ * use the [default loop](https://github.com/reactphp/event-loop#loop). This value
+ * SHOULD NOT be given unless you're sure you want to explicitly use a given event
+ * loop instance.
+ *
+ * The returned promise is implemented in such a way that it can be cancelled
+ * when it is still pending. Cancelling a pending promise will reject its value
+ * with a `RuntimeException` and clean up any pending timers.
+ *
+ * ```php
+ * $timer = React\Promise\Timer\sleep(2.0);
+ *
+ * $timer->cancel();
+ * ```
+ *
+ * @param float $time
+ * @param ?LoopInterface $loop
+ * @return PromiseInterface<void, \RuntimeException>
+ */
+function sleep($time, LoopInterface $loop = null)
+{
+    if ($loop === null) {
+        $loop = Loop::get();
+    }
+
+    $timer = null;
+    return new Promise(function ($resolve) use ($loop, $time, &$timer) {
+        // resolve the promise when the timer fires in $time seconds
+        $timer = $loop->addTimer($time, function () use ($resolve) {
+            $resolve();
+        });
+    }, function () use (&$timer, $loop) {
+        // cancelling this promise will cancel the timer, clean the reference
+        // in order to avoid garbage references in call stack and then reject.
+        $loop->cancelTimer($timer);
+        $timer = null;
+
+        throw new \RuntimeException('Timer cancelled');
+    });
+}
+
+/**
  * Create a new promise that resolves in `$time` seconds with the `$time` as the fulfillment value.
  *
  * ```php
@@ -228,23 +284,8 @@ function timeout(PromiseInterface $promise, $time, LoopInterface $loop = null)
  */
 function resolve($time, LoopInterface $loop = null)
 {
-    if ($loop === null) {
-        $loop = Loop::get();
-    }
-
-    $timer = null;
-    return new Promise(function ($resolve) use ($loop, $time, &$timer) {
-        // resolve the promise when the timer fires in $time seconds
-        $timer = $loop->addTimer($time, function () use ($time, $resolve) {
-            $resolve($time);
-        });
-    }, function () use (&$timer, $loop) {
-        // cancelling this promise will cancel the timer, clean the reference
-        // in order to avoid garbage references in call stack and then reject.
-        $loop->cancelTimer($timer);
-        $timer = null;
-
-        throw new \RuntimeException('Timer cancelled');
+    return sleep($time, $loop)->then(function() use ($time) {
+        return $time;
     });
 }
 
@@ -284,7 +325,7 @@ function resolve($time, LoopInterface $loop = null)
  */
 function reject($time, LoopInterface $loop = null)
 {
-    return resolve($time, $loop)->then(function ($time) {
+    return sleep($time, $loop)->then(function () use ($time) {
         throw new TimeoutException($time, 'Timer expired after ' . $time . ' seconds');
     });
 }

--- a/tests/FunctionSleepTest.php
+++ b/tests/FunctionSleepTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace React\Tests\Promise\Timer;
+
+use React\EventLoop\Loop;
+use React\Promise\Timer;
+
+class FunctionSleepTest extends TestCase
+{
+    public function testPromiseIsPendingWithoutRunningLoop()
+    {
+        $promise = Timer\sleep(0.01);
+
+        $this->expectPromisePending($promise);
+    }
+
+    public function testPromiseExpiredIsPendingWithoutRunningLoop()
+    {
+        $promise = Timer\sleep(-1);
+
+        $this->expectPromisePending($promise);
+    }
+
+    public function testPromiseWillBeResolvedOnTimeout()
+    {
+        $promise = Timer\sleep(0.01);
+
+        Loop::run();
+
+        $this->expectPromiseResolved($promise);
+    }
+
+    public function testPromiseExpiredWillBeResolvedOnTimeout()
+    {
+        $promise = Timer\sleep(-1);
+
+        Loop::run();
+
+        $this->expectPromiseResolved($promise);
+    }
+
+    public function testWillStartLoopTimer()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->with($this->equalTo(0.01));
+
+        Timer\sleep(0.01, $loop);
+    }
+
+    public function testCancellingPromiseWillCancelLoopTimer()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $timer = $this->getMockBuilder(interface_exists('React\EventLoop\TimerInterface') ? 'React\EventLoop\TimerInterface' : 'React\EventLoop\Timer\TimerInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->will($this->returnValue($timer));
+
+        $promise = Timer\sleep(0.01, $loop);
+
+        $loop->expects($this->once())->method('cancelTimer')->with($this->equalTo($timer));
+
+        $promise->cancel();
+    }
+
+    public function testCancellingPromiseWillRejectTimer()
+    {
+        $promise = Timer\sleep(0.01);
+
+        $promise->cancel();
+
+        $this->expectPromiseRejected($promise);
+    }
+
+    public function testWaitingForPromiseToResolveDoesNotLeaveGarbageCycles()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Timer\sleep(0.01);
+        Loop::run();
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testCancellingPromiseDoesNotLeaveGarbageCycles()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Timer\sleep(0.01);
+        $promise->cancel();
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+}


### PR DESCRIPTION
This changeset adds a new `sleep()` function and deprecates the `resolve()` and `reject()` functions in favor of the new `sleep()` function.

The new `sleep()` function does precisely what the current `resolve()` function does: It creates a promise that will be fulfilled in a given number of seconds. The only difference is that the `sleep()` function resolves with no value, whereas the `resolve()` function resolves with the number of seconds. The previous type was a pretty arbitrary design decision I made, the new type now matches how `usleep()` returns a `void`.

Using the name `sleep()` makes a lot more sense as introducing an asynchronous delay is a rather common requirement and it makes sense to mimic PHP's built-in `sleep()` function. On top of this, this also helps avoid any ambiguities, as the `React\Promise\resolve()` function does something entirely different than the `React\Promise\Timer\resolve()` function (same local name, only different namespace). This is also a major DX improvement, as IDE autocompletion would *always* suggest the wrong function import, let alone the fact that you wouldn't look for a function named "resolve" if you want to "sleep".

Similarly, the `reject()` function was mostly added to complement the `resolve()` function, but I don't see any real-world use cases for this. Implementing this on top of the `sleep()` function is trivial (see its implementation), so I will argue it provides very little value.

Builds on top of #49