### PR TITLE
Improve `TimeoutException` legacy API by using explicit type casts

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Promise Timer Test Suite">
             <directory>./tests/</directory>

--- a/src/TimeoutException.php
+++ b/src/TimeoutException.php
@@ -11,22 +11,16 @@ class TimeoutException extends RuntimeException
 
     /**
      * @param float                      $timeout
-     * @param ?string                    $message
-     * @param ?int                       $code
+     * @param string|null                $message
+     * @param int|null                   $code
      * @param null|\Exception|\Throwable $previous
      */
-    public function __construct($timeout, $message = null, $code = null, $previous = null)
+    public function __construct($timeout, $message = '', $code = 0, $previous = null)
     {
-        // Preserve compatibility with our former signature, but avoid invalid arguments for the parent constructor:
-        if ($message === null) {
-            $message = '';
-        }
-        if ($code === null) {
-            $code = 0;
-        }
-        parent::__construct($message, $code, $previous);
+        // Preserve compatibility with our former nullable signature, but avoid invalid arguments for the parent constructor:
+        parent::__construct((string) $message, (int) $code, $previous);
 
-        $this->timeout = $timeout;
+        $this->timeout = (float) $timeout;
     }
 
     /**

--- a/tests/TimeoutExceptionTest.php
+++ b/tests/TimeoutExceptionTest.php
@@ -2,47 +2,45 @@
 
 namespace React\Tests\Promise\Timer;
 
-use ErrorException;
 use React\Promise\Timer\TimeoutException;
 
 class TimeoutExceptionTest extends TestCase
 {
-    public function testAccessTimeout()
+    public function testCtorWithAllParameters()
     {
-        $e = new TimeoutException(10);
+        $previous = new \Exception();
+        $e = new TimeoutException(1.0, 'Error', 42, $previous);
 
-        $this->assertEquals(10, $e->getTimeout());
+        $this->assertEquals(1.0, $e->getTimeout());
+        $this->assertEquals('Error', $e->getMessage());
+        $this->assertEquals(42, $e->getCode());
+        $this->assertSame($previous, $e->getPrevious());
     }
 
-    public function testEnsureNoDeprecationsAreTriggered()
+    public function testCtorWithDefaultValues()
     {
-        $formerReporting = error_reporting();
-        error_reporting(E_ALL | E_STRICT);
-        $this->setStrictErrorHandling();
+        $e = new TimeoutException(2.0);
 
-        try {
-            $e = new TimeoutException(10);
-        } catch (ErrorException $e) {
-            error_reporting($formerReporting);
-            throw $e;
-        }
-
-        error_reporting($formerReporting);
-        $this->assertEquals(10, $e->getTimeout());
+        $this->assertEquals(2.0, $e->getTimeout());
+        $this->assertEquals('', $e->getMessage());
+        $this->assertEquals(0, $e->getCode());
+        $this->assertNull($e->getPrevious());
     }
 
-    protected function setStrictErrorHandling()
+    public function testCtorWithIntTimeoutWillBeReturnedAsFloat()
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            if (! (error_reporting() & $errno)) {
-                return false;
-            }
-            switch ($errno) {
-                case E_DEPRECATED:
-                    throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
-            }
+        $e = new TimeoutException(1);
 
-            return false;
-        });
+        $this->assertSame(1.0, $e->getTimeout());
+    }
+
+    public function testLegacyCtorWithNullValues()
+    {
+        $e = new TimeoutException(10, null, null, null);
+
+        $this->assertEquals(10.0, $e->getTimeout());
+        $this->assertEquals('', $e->getMessage());
+        $this->assertEquals(0, $e->getCode());
+        $this->assertNull($e->getPrevious());
     }
 }


### PR DESCRIPTION
This changeset improves the `TimeoutException` legacy API by using explicit type casts. This simplifies the logic implemented in #50 but otherwise preserves the exact same behavior.

Builds on top of #50 and #49