### PR TITLE
Fix legacy HHVM build by downgrading Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,6 @@ jobs:
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30
+      - run: composer self-update --2.2 # downgrade Composer for HHVM
       - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PromiseTimer
 
-[![CI status](https://github.com/reactphp/promise-timer/workflows/CI/badge.svg)](https://github.com/reactphp/promise-timer/actions)
+[![CI status](https://github.com/reactphp/promise-timer/actions/workflows/ci.yml/badge.svg)](https://github.com/reactphp/promise-timer/actions)
 [![installs on Packagist](https://img.shields.io/packagist/dt/react/promise-timer?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/react/promise-timer)
 
 A trivial implementation of timeouts for `Promise`s, built on top of [ReactPHP](https://reactphp.org/).


### PR DESCRIPTION
Builds on top of the work done by @clue and the discussion inside reactphp/socket#289.

I also updated the path for the CI badge.