### PR TITLE
Template params can only have one argument

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -129,10 +129,10 @@ use React\Promise\PromiseInterface;
  * For more details on the promise primitives, please refer to the
  * [Promise documentation](https://github.com/reactphp/promise#functions).
  *
- * @param PromiseInterface<mixed, \Throwable|mixed> $promise
+ * @param PromiseInterface<mixed> $promise
  * @param float $time
  * @param ?LoopInterface $loop
- * @return PromiseInterface<mixed, TimeoutException|\Throwable|mixed>
+ * @return PromiseInterface<mixed>
  */
 function timeout(PromiseInterface $promise, $time, LoopInterface $loop = null)
 {
@@ -219,7 +219,7 @@ function timeout(PromiseInterface $promise, $time, LoopInterface $loop = null)
  *
  * @param float $time
  * @param ?LoopInterface $loop
- * @return PromiseInterface<void, \RuntimeException>
+ * @return PromiseInterface<void>
  */
 function sleep($time, LoopInterface $loop = null)
 {
@@ -275,7 +275,7 @@ function sleep($time, LoopInterface $loop = null)
  *
  * @param float $time
  * @param ?LoopInterface $loop
- * @return PromiseInterface<float, \RuntimeException>
+ * @return PromiseInterface<float>
  * @deprecated 1.8.0 See `sleep()` instead
  * @see sleep()
  */
@@ -318,7 +318,7 @@ function resolve($time, LoopInterface $loop = null)
  *
  * @param float         $time
  * @param LoopInterface $loop
- * @return PromiseInterface<void, TimeoutException|\RuntimeException>
+ * @return PromiseInterface<void>
  * @deprecated 1.8.0 See `sleep()` instead
  * @see sleep()
  */


### PR DESCRIPTION
The fact that a promise can also be rejected with a Throwable and/or Exception is implied and there is no need to also define that here.

Refs: https://github.com/reactphp/promise/pull/223