### PR TITLE
Template params can only have one argument - README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Timer\timeout(…);
 
 ### timeout()
 
-The `timeout(PromiseInterface<mixed, Throwable|mixed> $promise, float $time, ?LoopInterface $loop = null): PromiseInterface<mixed, TimeoutException|Throwable|mixed>` function can be used to
+The `timeout(PromiseInterface<mixed> $promise, float $time, ?LoopInterface $loop = null): PromiseInterface<mixed>` function can be used to
 cancel operations that take *too long*.
 
 You need to pass in an input `$promise` that represents a pending operation
@@ -171,7 +171,7 @@ For more details on the promise primitives, please refer to the
 
 ### sleep()
 
-The `sleep(float $time, ?LoopInterface $loop = null): PromiseInterface<void, RuntimeException>` function can be used to
+The `sleep(float $time, ?LoopInterface $loop = null): PromiseInterface<void>` function can be used to
 create a new promise that resolves in `$time` seconds.
 
 ```php
@@ -205,7 +205,7 @@ $timer->cancel();
 
 > Deprecated since v1.8.0, see [`sleep()`](#sleep) instead.
 
-The `resolve(float $time, ?LoopInterface $loop = null): PromiseInterface<float, RuntimeException>` function can be used to
+The `resolve(float $time, ?LoopInterface $loop = null): PromiseInterface<float>` function can be used to
 create a new promise that resolves in `$time` seconds with the `$time` as the fulfillment value.
 
 ```php
@@ -239,7 +239,7 @@ $timer->cancel();
 
 > Deprecated since v1.8.0, see [`sleep()`](#sleep) instead.
 
-The `reject(float $time, ?LoopInterface $loop = null): PromiseInterface<void, TimeoutException|RuntimeException>` function can be used to
+The `reject(float $time, ?LoopInterface $loop = null): PromiseInterface<void>` function can be used to
 create a new promise which rejects in `$time` seconds with a `TimeoutException`.
 
 ```php


### PR DESCRIPTION
In the previous PR (https://github.com/reactphp/promise-timer/pull/63) I missed incorrect usage in the readme, this PR addresses that.

The fact that a promise can also be rejected with a Throwable and/or Exception is implied and there is no need to also define that here.

Refs: https://github.com/reactphp/promise/pull/223