### PR TITLE
Use Promise v3 template types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
-      - name: Run hhvm composer.phar install
+      - name: Run hhvm composer.phar require react/promise:^2 # downgrade Promise for HHVM
         uses: docker://hhvm/hhvm:3.30-lts-latest
         with:
-          args: hhvm composer.phar install
+          args: hhvm composer.phar require react/promise:^2
       - name: Run hhvm vendor/bin/phpunit
         uses: docker://hhvm/hhvm:3.30-lts-latest
         with:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Timer\timeout(…);
 
 ### timeout()
 
-The `timeout(PromiseInterface<mixed> $promise, float $time, ?LoopInterface $loop = null): PromiseInterface<mixed>` function can be used to
+The `timeout(PromiseInterface<T> $promise, float $time, ?LoopInterface $loop = null): PromiseInterface<T>` function can be used to
 cancel operations that take *too long*.
 
 You need to pass in an input `$promise` that represents a pending operation
@@ -239,7 +239,7 @@ $timer->cancel();
 
 > Deprecated since v1.8.0, see [`sleep()`](#sleep) instead.
 
-The `reject(float $time, ?LoopInterface $loop = null): PromiseInterface<void>` function can be used to
+The `reject(float $time, ?LoopInterface $loop = null): PromiseInterface<never>` function can be used to
 create a new promise which rejects in `$time` seconds with a `TimeoutException`.
 
 ```php

--- a/src/functions.php
+++ b/src/functions.php
@@ -129,10 +129,11 @@ use React\Promise\PromiseInterface;
  * For more details on the promise primitives, please refer to the
  * [Promise documentation](https://github.com/reactphp/promise#functions).
  *
- * @param PromiseInterface<mixed> $promise
+ * @template T
+ * @param PromiseInterface<T> $promise
  * @param float $time
  * @param ?LoopInterface $loop
- * @return PromiseInterface<mixed>
+ * @return PromiseInterface<T>
  */
 function timeout(PromiseInterface $promise, $time, LoopInterface $loop = null)
 {
@@ -318,7 +319,7 @@ function resolve($time, LoopInterface $loop = null)
  *
  * @param float         $time
  * @param LoopInterface $loop
- * @return PromiseInterface<void>
+ * @return PromiseInterface<never>
  * @deprecated 1.8.0 See `sleep()` instead
  * @see sleep()
  */


### PR DESCRIPTION
This simple changeset adds proper Promise v3 template types to describe API arguments and return values. The change is pretty straightforward, as most of the work was done upstream and in previous PRs linked below.

Note that this project doesn't currently use PHPStan itself, so this is a bit harder to reproduce on its own. I've tested this in a number of downstream projects and it appears this is the minimal changeset required to make downstream projects work that depend on these functions. I'll link relevant PRs against this one for reference.

I'd vote to get this in as is for now to make sure we unblock any downstream projects. Note that this doesn't preclude how and/or whether we're going to integrate PHPStan into pre-v3 components like this one as already discussed in https://github.com/reactphp/async/pull/77.

Builds on top of https://github.com/reactphp/promise/pull/247, #64 and #63