### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=5.3",
         "react/event-loop": "^1.2",
-        "react/promise": "^3.0 || ^2.7.0 || ^1.2.1"
+        "react/promise": "^3.2 || ^2.7.0 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"

--- a/src/functions.php
+++ b/src/functions.php
@@ -135,8 +135,12 @@ use React\Promise\PromiseInterface;
  * @param ?LoopInterface $loop
  * @return PromiseInterface<T>
  */
-function timeout(PromiseInterface $promise, $time, LoopInterface $loop = null)
+function timeout(PromiseInterface $promise, $time, $loop = null)
 {
+    if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+        throw new \InvalidArgumentException('Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+    }
+
     // cancelling this promise will only try to cancel the input promise,
     // thus leaving responsibility to the input promise.
     $canceller = null;
@@ -222,8 +226,12 @@ function timeout(PromiseInterface $promise, $time, LoopInterface $loop = null)
  * @param ?LoopInterface $loop
  * @return PromiseInterface<void>
  */
-function sleep($time, LoopInterface $loop = null)
+function sleep($time, $loop = null)
 {
+    if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+        throw new \InvalidArgumentException('Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
+    }
+
     if ($loop === null) {
         $loop = Loop::get();
     }
@@ -280,7 +288,7 @@ function sleep($time, LoopInterface $loop = null)
  * @deprecated 1.8.0 See `sleep()` instead
  * @see sleep()
  */
-function resolve($time, LoopInterface $loop = null)
+function resolve($time, $loop = null)
 {
     return sleep($time, $loop)->then(function() use ($time) {
         return $time;
@@ -317,13 +325,13 @@ function resolve($time, LoopInterface $loop = null)
  * $timer->cancel();
  * ```
  *
- * @param float         $time
- * @param LoopInterface $loop
+ * @param float $time
+ * @param ?LoopInterface $loop
  * @return PromiseInterface<never>
  * @deprecated 1.8.0 See `sleep()` instead
  * @see sleep()
  */
-function reject($time, LoopInterface $loop = null)
+function reject($time, $loop = null)
 {
     return sleep($time, $loop)->then(function () use ($time) {
         throw new TimeoutException($time, 'Timer expired after ' . $time . ' seconds');

--- a/tests/FunctionRejectTest.php
+++ b/tests/FunctionRejectTest.php
@@ -48,6 +48,12 @@ class FunctionRejectTest extends TestCase
         $this->expectPromiseRejected($promise);
     }
 
+    public function testRejectWithInvalidLoopThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
+        Timer\reject(1.0, 42);
+    }
+
     public function testWaitingForPromiseToRejectDoesNotLeaveGarbageCycles()
     {
         if (class_exists('React\Promise\When')) {

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -70,6 +70,12 @@ class FunctionResolveTest extends TestCase
         $this->expectPromiseRejected($promise);
     }
 
+    public function testResolveWithInvalidLoopThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
+        Timer\resolve(1.0, 42);
+    }
+
     public function testWaitingForPromiseToResolveDoesNotLeaveGarbageCycles()
     {
         if (class_exists('React\Promise\When')) {

--- a/tests/FunctionSleepTest.php
+++ b/tests/FunctionSleepTest.php
@@ -70,6 +70,12 @@ class FunctionSleepTest extends TestCase
         $this->expectPromiseRejected($promise);
     }
 
+    public function testSleepWithInvalidLoopThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
+        Timer\sleep(1.0, 42);
+    }
+
     public function testWaitingForPromiseToResolveDoesNotLeaveGarbageCycles()
     {
         if (class_exists('React\Promise\When')) {

--- a/tests/FunctionTimeoutTest.php
+++ b/tests/FunctionTimeoutTest.php
@@ -184,6 +184,12 @@ class FunctionTimeoutTest extends TestCase
         $this->expectPromiseResolved($timeout);
     }
 
+    public function testTimeoutWithInvalidLoopThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+        Timer\timeout(Promise\resolve(null), 1.0, 42);
+    }
+
     public function testWaitingForPromiseToResolveBeforeTimeoutDoesNotLeaveGarbageCycles()
     {
         if (class_exists('React\Promise\When')) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,6 +42,21 @@ class TestCase extends BaseTestCase
         }
     }
 
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            $this->expectExceptionMessage($exceptionMessage);
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
+
     protected function expectPromiseRejected($promise)
     {
         return $promise->then($this->expectCallableNever(), $this->expectCallableOnce());


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

~~Marking this as WIP until the upstream components have been released. In the meantime, this may use temporary development branches.~~

Builds on top of #68, #46 and https://github.com/reactphp/promise/pull/260